### PR TITLE
allow hash model name specification

### DIFF
--- a/src/newick.py
+++ b/src/newick.py
@@ -274,9 +274,14 @@ def _parse_tree(tstring, flags, internal_node_count, index):
                 if tstring[index] == '#':
                     # If node label is followed by the hash sign (#), this means everything after is the model name
                     model_flag, index = _read_hash_model_flag(tstring, index)
+                    if model_flag.endswith("#"):
+                        # Exclamation suffix means that model should be propagated
+                        model_flag = model_flag[:-1]
+                    else:
+                        # Hash model flags are not propagated by default
+                        node.sticky_model = False
+
                     node.model_flag = model_flag
-                    # Hash model flags are not propagated
-                    node.sticky_model = False
 
                 # Quick warning to prevent users from supply root names
                 try:

--- a/src/newick.py
+++ b/src/newick.py
@@ -23,6 +23,7 @@ class Node():
         self.children       = []   # List of children, each of which is a Node object itself. If len(children) == 0, this tree is a tip.
         self.branch_length  = None # Branch length leading up to node
         self.model_flag     = None # Flag indicate that this branch evolves according to a distinct model from parent
+        self.sticky_model   = True # Propagate model flag to the child nodes
         self.seq            = None # Contains sequence (represented by integers) for a given node. Later, this may instead be a list of Site objects.
 
 
@@ -145,7 +146,8 @@ def _assign_model_flags_to_nodes(nroots, tree, parent_flag = None):
 
     if len(tree.children) > 0:
         for node in tree.children:
-            parent_flag, nroots = _assign_model_flags_to_nodes(nroots, node, tree.model_flag)
+            children_model_flag = tree.model_flag if tree.sticky_model else None
+            parent_flag, nroots = _assign_model_flags_to_nodes(nroots, node, children_model_flag)
     return parent_flag, nroots
     
 
@@ -273,6 +275,8 @@ def _parse_tree(tstring, flags, internal_node_count, index):
                     # If node label is followed by the hash sign (#), this means everything after is the model name
                     model_flag, index = _read_hash_model_flag(tstring, index)
                     node.model_flag = model_flag
+                    # Hash model flags are not propagated
+                    node.sticky_model = False
 
                 # Quick warning to prevent users from supply root names
                 try:

--- a/src/newick.py
+++ b/src/newick.py
@@ -239,6 +239,12 @@ def _read_leaf(tstring, index):
     # Does leaf have a model? 
     if tstring[end] == '_':
         node.model_flag, end = _read_model_flag(tstring, end)
+    # Does leaf have a hash model specification?
+    if '#' in node.name:
+        node.name, node.model_flag = node.name.split('#', 1)
+        # Remove extra terminal '#' if present; it's meaningles for a leaf node
+        if node.model_flag.endswith('#'):
+            node.model_flag = node.model_flag[:-1]
     return node, end
 
 


### PR DESCRIPTION
As discussed in #1, this is the implementation of the proposed changes.

It stays backwards compatible, while allowing a new more powerful hash model specification syntax.

```
(t4:0.785,(t3:0.380,(t2:0.806,(t5:0.612,t1:0.660)#m1:0.762)#m2:0.921):0.207); # this is only for single branches
(t4:0.785,(t3:0.380,(t2:0.806,(t5:0.612,t1:0.660):0.762)#m2#:0.921):0.207); # this will propagate
```

Please let me know what do you think.

If you like it, in future this syntax could probably be used as a default one. It's similar to how fastcodeml and paml branch labeling works. And somewhat similar to the indelible and  hyphy ways of labeling branches.